### PR TITLE
feat: do not validate OTP versions

### DIFF
--- a/__tests__/setup-beam.test.js
+++ b/__tests__/setup-beam.test.js
@@ -15,7 +15,6 @@ async function all() {
   await testFailInstallGleam()
   await testFailInstallRebar3()
 
-  await testOTPVersions()
   await testElixirVersions()
   await testGleamVersions()
   await testRebar3Versions()
@@ -94,77 +93,6 @@ async function testFailInstallRebar3() {
     },
     `Installing rebar3 ${r3Version} is supposed to fail`,
   )
-}
-
-async function testOTPVersions() {
-  let got
-  let expected
-  let spec
-  let osVersion
-
-  if (process.platform === 'linux') {
-    spec = '19.3.x'
-    osVersion = 'ubuntu-16.04'
-    expected = 'OTP-19.3.6.13'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '^19.3.6'
-    osVersion = 'ubuntu-16.04'
-    expected = 'OTP-19.3.6.13'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '^19.3'
-    osVersion = 'ubuntu-18.04'
-    expected = 'OTP-19.3.6.13'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '20'
-    osVersion = 'ubuntu-20.04'
-    expected = 'OTP-20.3.8.26'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '20.x'
-    osVersion = 'ubuntu-20.04'
-    expected = 'OTP-20.3.8.26'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '20.0'
-    osVersion = 'ubuntu-20.04'
-    expected = 'OTP-20.0.5'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '20.0.x'
-    osVersion = 'ubuntu-20.04'
-    expected = 'OTP-20.0.5'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-  }
-
-  if (process.platform === 'win32') {
-    spec = '24.0.1'
-    osVersion = 'windows-latest'
-    expected = '24.0.1'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '23.2.x'
-    osVersion = 'windows-2016'
-    expected = '23.2.7'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-
-    spec = '23.0'
-    osVersion = 'windows-2019'
-    expected = '23.0.4'
-    got = await setupBeam.getOTPVersion(spec, osVersion)
-    assert.deepStrictEqual(got, expected)
-  }
 }
 
 async function testElixirVersions() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7219,14 +7219,14 @@ async function main() {
   }
 
   const osVersion = getRunnerOSVersion()
-  const otpSpec = getInput('otp-version', true, 'erlang', versions)
+  const otpVersion = getInput('otp-version', true, 'erlang', versions)
   const elixirSpec = getInput('elixir-version', false, 'elixir', versions)
   const gleamSpec = getInput('gleam-version', false, 'gleam', versions)
   const rebar3Spec = getInput('rebar3-version', false, 'rebar', versions)
 
-  if (otpSpec !== 'false') {
-    await installOTP(otpSpec, osVersion)
-    const elixirInstalled = await maybeInstallElixir(elixirSpec, otpSpec)
+  if (otpVersion !== 'false') {
+    await installOTP(otpVersion, osVersion)
+    const elixirInstalled = await maybeInstallElixir(elixirSpec, otpVersion)
 
     if (elixirInstalled === true) {
       const shouldMixRebar = getInput('install-rebar', false)
@@ -7242,8 +7242,7 @@ async function main() {
   await maybeInstallRebar3(rebar3Spec)
 }
 
-async function installOTP(otpSpec, osVersion) {
-  const otpVersion = await getOTPVersion(otpSpec, osVersion)
+async function installOTP(otpVersion, osVersion) {
   console.log(
     `##[group]Installing Erlang/OTP ${otpVersion} - built on ${osVersion}`,
   )
@@ -7329,26 +7328,6 @@ async function maybeInstallRebar3(rebar3Spec) {
   return installed
 }
 
-async function getOTPVersion(otpSpec0, osVersion) {
-  const otpVersions = await getOTPVersions(osVersion)
-  let otpSpec = otpSpec0 // might be a branch (?)
-  const otpVersion = getVersionFromSpec(
-    otpSpec,
-    Array.from(otpVersions.keys()).sort(),
-  )
-  if (isVersion(otpSpec0)) {
-    otpSpec = `OTP-${otpSpec0}` // ... it's a version!
-  }
-  if (otpVersion === null) {
-    throw new Error(
-      `Requested Erlang/OTP version (${otpSpec0}) not found in version list ` +
-        "(should you be using option 'version-type': 'strict'?)",
-    )
-  }
-
-  return otpVersions.get(otpVersion) // from the reference, for download
-}
-
 async function getElixirVersion(exSpec0, otpVersion0) {
   const otpVersion = otpVersion0.match(/^([^-]+-)?(.+)$/)[2]
   const otpVersionMajor = otpVersion.match(/^([^.]+).*$/)[1]
@@ -7410,48 +7389,6 @@ async function getRebar3Version(r3Spec) {
   }
 
   return rebar3Version
-}
-
-async function getOTPVersions(osVersion) {
-  let originListing
-  let pageIdxs
-  if (process.platform === 'linux') {
-    originListing = `https://repo.hex.pm/builds/otp/${osVersion}/builds.txt`
-    pageIdxs = [null]
-  } else if (process.platform === 'win32') {
-    originListing =
-      'https://api.github.com/repos/erlang/otp/releases?per_page=100'
-    pageIdxs = [1, 2, 3]
-  }
-
-  const otpVersionsListings = await get(originListing, pageIdxs)
-  const otpVersions = new Map()
-
-  if (process.platform === 'linux') {
-    otpVersionsListings
-      .trim()
-      .split('\n')
-      .forEach((line) => {
-        const otpMatch = line
-          .match(/^([^ ]+)?( .+)/)[1]
-          .match(/^([^-]+-)?(.+)$/)
-        const otpVersion = otpMatch[2]
-        otpVersions.set(otpVersion, otpMatch[0]) // we keep the original for later reference
-      })
-  } else if (process.platform === 'win32') {
-    otpVersionsListings.forEach((otpVersionsListing) => {
-      JSON.parse(otpVersionsListing)
-        .map((x) => x.assets)
-        .flat()
-        .filter((x) => x.name.match(/^otp_win64_.*.exe$/))
-        .forEach((x) => {
-          const otpMatch = x.name.match(/^otp_win64_(.*).exe$/)
-          const otpVersion = otpMatch[1]
-          otpVersions.set(otpVersion, otpVersion)
-        })
-    })
-  }
-  return otpVersions
 }
 
 async function getElixirVersions() {
@@ -7717,7 +7654,6 @@ function parseVersionFile(versionFilePath0) {
 }
 
 module.exports = {
-  getOTPVersion,
   getElixirVersion,
   getGleamVersion,
   getRebar3Version,


### PR DESCRIPTION
Right now erlef/setup-beam is failing intermittently when trying to validate supplied OTP version from input against official releases on github.

Since we always use specific version, we don't need this functionality. Everything else works just fine.

See also https://github.com/erlef/setup-beam/issues/167